### PR TITLE
Allow: composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "comwrap/module-elasticsuite-blog-search",
+    "name": "comwrap/comwrap_elasticsuiteblog",
     "type": "magento2-module",
     "version": "1.0.0",
     "license": ["OSL-3.0",  "AFL-3.0"],


### PR DESCRIPTION
### Changed "name" field:
from:
```"name": "comwrap/module-elasticsuite-blog-search"```
to:
```"name": "comwrap/comwrap_elasticsuiteblog"```

### The reason:

After appending to composer.json:
```
    "repositories": {
...
        "comwrap-comwrap_elasticsuiteblog": {
            "url": "https://github.com/comwrap/Comwrap_ElasticsuiteBlog",
            "type":"git"
        }
...
```

### Allowed:

```$ composer require comwrap/comwrap_elasticsuiteblog```

### Initial status:
``` $ composer require comwrap/comwrap_elasticsuiteblog```
### provided with the issue:

```Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package comwrap/comwrap_elasticsuiteblog could not be found in any version, there may be a typo in the package name.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```