### PR TITLE
Fix for indexer_update_all_views cron job

### DIFF
--- a/Model/Post/Indexer/Fulltext.php
+++ b/Model/Post/Indexer/Fulltext.php
@@ -50,7 +50,7 @@ class Fulltext implements ActionInterface, MviewActionInterface
         IndexerInterface $indexerHandler,
         StoreManagerInterface $storeManager,
         DimensionFactory $dimensionFactory,
-        array $data
+        $data = []
     ) {
         $this->fullAction = $fullAction;
         $this->indexerHandler = $indexerHandler;


### PR DESCRIPTION
Hi there,

We have been using this module for a few days now and we noticed one of our cron jobs failed (indexer_update_all_views). Every change you'd make in the backend (product, category), would never be visible on the frontend (without running the indexers manually). Pretty heavy bug!

It was because of the following error;
`Missing required argument $data of Comwrap\ElasticsuiteBlog\Model\Post\Indexer\Fulltext.`

We are using Magento version: 2.3.2

Reproducing:
Local environment with this elasticsuite + this module + magefan blog module
`php bin/magento cron:run` first time to schedule
`php bin/magento cron:run` second time to run the scheduled jobs

Thanks in advance!
Gr, Raphael