### PR TITLE
Fix proper usage of Magento framework reference

### DIFF
--- a/Model/ResourceModel/Post/Fulltext/Collection.php
+++ b/Model/ResourceModel/Post/Fulltext/Collection.php
@@ -101,7 +101,7 @@ class Collection extends \Magefan\Blog\Model\ResourceModel\Post\Collection
     /**
      * {@inheritDoc}
      */
-    public function setOrder($attribute, $dir = Select::SQL_DESC)
+    public function setOrder($attribute, $dir = \Magento\Framework\DB\Select::SQL_DESC)
     {
         throw new \LogicException("Sorting on multiple stores is not allowed in search engine collections.");
     }


### PR DESCRIPTION
This fix an issue on magento commerce 2.3.3 and smile/elasticsuite version 2.8.2

I have attached the error below. hope this helps
Fatal error: Class 'Comwrap\ElasticsuiteBlog\Model\ResourceModel\Post\Fulltext\Select' not found in vendor/magento/framework/Code/Generator/EntityAbstract.php on line 350