### PR TITLE
Fix fatal error after adding is_active filter

### DIFF
--- a/etc/elasticsuite_indices.xml
+++ b/etc/elasticsuite_indices.xml
@@ -14,6 +14,7 @@
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>
+		<field name="is_active" type="integer" />
             </mapping>
         </type>
     </index>


### PR DESCRIPTION
After adding the `is_active` filter to the collection, the following error occurs:
LogicException: Field is_active does not exist in mapping
Commit: https://github.com/comwrap/Comwrap_ElasticsuiteBlog/commit/79e1439aebec43663549143c6ea1271b867e2b67